### PR TITLE
instant application when new outputs are connected

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -128,6 +128,10 @@ pub trait ColorTemperatureBackend {
     /// A string identifying the backend (e.g., "Hyprland", "Wayland")
     fn backend_name(&self) -> &'static str;
 
+    /// Perform a quick, non-blocking hotplug poll and apply if needed.
+    /// Default no-op; backends that support dynamic outputs can override.
+    fn poll_hotplug(&mut self) -> Result<()> { Ok(()) }
+
     /// Perform backend-specific cleanup operations.
     ///
     /// This method is called during application shutdown to clean up any


### PR DESCRIPTION
I noticed that when connecting new outputs in niri, the sunstr service would need to be restarted in order for the filter to be applied to the new displays. 

This adds a new lightweight poll function that should instantly update new outputs as soon as they are detected in wayland.