### PR TITLE
chore/add missing timezones

### DIFF
--- a/src/geo/timezone.rs
+++ b/src/geo/timezone.rs
@@ -2872,7 +2872,7 @@ pub(crate) fn get_city_from_timezone(tz_str: &str) -> Option<CityInfo> {
         "Indian/Comoro" => Some(CityInfo {
             name: "Moroni".to_string(),
             country: "Cocos (Keeling) Islands".to_string(),
-            latitude: 11.536667,
+            latitude: -11.536667,
             longitude: 43.271389,
         }),
         "Indian/Kerguelen" => Some(CityInfo {


### PR DESCRIPTION
There are a lot of timezones which were missing from the list.  I have added a bunch of them, while referring to the file:
[timezone.txt](https://github.com/user-attachments/files/23427031/timezone.txt)

The full list of timezones could be found [here](https://man.archlinux.org/man/DateTime::TimeZone::Catalog.3pm.en).