### PR TITLE
Use weighted harmonic mean for temperature interpolation

### DIFF
--- a/src/common/constants.rs
+++ b/src/common/constants.rs
@@ -82,9 +82,9 @@ pub const MAXIMUM_UPDATE_INTERVAL: u64 = 300; // seconds (5 minutes max for resp
 // - For linear-like: P1=(0.33, 0.33), P2=(0.67, 0.67)
 // - For ease-in only (slow start, fast end): P1=(0.42, 0.0), P2=(1.0, 1.0)
 
-pub const BEZIER_P1X: f32 = 0.33; // X coordinate of first control point (0.0 to 0.5)
-pub const BEZIER_P1Y: f32 = 0.07; // Y coordinate of first control point (typically 0.0)
-pub const BEZIER_P2X: f32 = 0.33; // X coordinate of second control point (0.5 to 1.0)
+pub const BEZIER_P1X: f32 = 0.2; // X coordinate of first control point (0.0 to 0.5)
+pub const BEZIER_P1Y: f32 = 0.0; // Y coordinate of first control point (typically 0.0)
+pub const BEZIER_P2X: f32 = 0.8; // X coordinate of second control point (0.5 to 1.0)
 pub const BEZIER_P2Y: f32 = 1.0; // Y coordinate of second control point (typically 1.0)
 
 // # Socket Communication Constants

--- a/src/core/runtime_state.rs
+++ b/src/core/runtime_state.rs
@@ -11,7 +11,7 @@ use std::fmt;
 use crate::common::constants::{
     DEFAULT_DAY_GAMMA, DEFAULT_DAY_TEMP, DEFAULT_NIGHT_GAMMA, DEFAULT_NIGHT_TEMP,
 };
-use crate::common::utils::{interpolate_f32, interpolate_u32};
+use crate::common::utils::{interpolate_f32, interpolate_inverse_u32};
 use crate::config::Config;
 use crate::core::period::{
     Period, calculate_sunrise_progress_for_period, calculate_sunset_progress_for_period,
@@ -59,13 +59,13 @@ impl RuntimeState {
                 let progress = self.progress().unwrap_or(0.0);
                 let day_temp = self.config.day_temp.unwrap_or(DEFAULT_DAY_TEMP);
                 let night_temp = self.config.night_temp.unwrap_or(DEFAULT_NIGHT_TEMP);
-                interpolate_u32(day_temp, night_temp, progress)
+                interpolate_inverse_u32(day_temp, night_temp, progress)
             }
             Period::Sunrise => {
                 let progress = self.progress().unwrap_or(0.0);
                 let day_temp = self.config.day_temp.unwrap_or(DEFAULT_DAY_TEMP);
                 let night_temp = self.config.night_temp.unwrap_or(DEFAULT_NIGHT_TEMP);
-                interpolate_u32(night_temp, day_temp, progress)
+                interpolate_inverse_u32(night_temp, day_temp, progress)
             }
         }
     }

--- a/src/core/smoothing.rs
+++ b/src/core/smoothing.rs
@@ -23,7 +23,7 @@ use std::time::{Duration, Instant};
 use crate::backend::ColorTemperatureBackend;
 use crate::common::constants::*;
 use crate::common::logger::Log;
-use crate::common::utils::{ProgressBar, interpolate_f32, interpolate_u32};
+use crate::common::utils::{ProgressBar, interpolate_f32, interpolate_inverse_u32};
 use crate::core::period::Period;
 
 /// Type of smooth transition being performed.
@@ -725,7 +725,7 @@ impl SmoothTransition {
             let (target_temp, target_gamma) = self.calculate_current_target(current_runtime_state);
 
             // Calculate current interpolated values
-            let current_temp = interpolate_u32(self.start_temp, target_temp, progress);
+            let current_temp = interpolate_inverse_u32(self.start_temp, target_temp, progress);
             let current_gamma = interpolate_f32(self.start_gamma, target_gamma, progress);
 
             // Draw the progress bar if enabled

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -625,8 +625,8 @@ mod property_tests {
             temp2 in 1000u32..20000,
             progress in 0.0f32..1.0
         ) {
-            use sunsetr::utils::interpolate_u32;
-            let result = interpolate_u32(temp1, temp2, progress);
+            use sunsetr::utils::interpolate_inverse_u32;
+            let result = interpolate_inverse_u32(temp1, temp2, progress);
             let min_temp = temp1.min(temp2);
             let max_temp = temp1.max(temp2);
             prop_assert!(result >= min_temp && result <= max_temp);


### PR DESCRIPTION
Interpolating color temperatures in the "inverse space" to make transitions perceptually uniform. More info in #44.

This modifies the original utility function `interpolate_u32`.

Just not sure about the naming. I chose `interpolate_inverse_u32` to signify it's not just a simple lerp, but maybe `interpolate_temp_u32` could also work?