### PR TITLE
Desaturate extreme temperatures to improve colors

### DIFF
--- a/src/backend/hyprland/mod.rs
+++ b/src/backend/hyprland/mod.rs
@@ -203,38 +203,46 @@ impl HyprlandBackend {
             let g_adjusted = g * gamma_ratio;
             let b_adjusted = b * gamma_ratio;
 
+            // Calculate saturation to improve colors at extreme temperatures
+            let desaturation_strength = 0.4;
+            let distance_from_d65 = (6500.0 / self.current_temperature as f32 - 1.0).abs();
+            let saturation = 0.5f32.powf(desaturation_strength * distance_from_d65);
+
+            // Rec709 luminance weights
+            let weight_r = 0.2126;
+            let weight_g = 0.7152;
+            let weight_b = 0.0722;
+
+            // Create CTM matrix
+            // CTM is row-major 3x3 matrix
+            let ctm = [
+                r_adjusted * (saturation * (1.0 - weight_r) + weight_r),
+                r_adjusted * (1.0 - saturation) * weight_g,
+                r_adjusted * (1.0 - saturation) * weight_b,
+                g_adjusted * (1.0 - saturation) * weight_r,
+                g_adjusted * (saturation * (1.0 - weight_g) + weight_g),
+                g_adjusted * (1.0 - saturation) * weight_b,
+                b_adjusted * (1.0 - saturation) * weight_r,
+                b_adjusted * (1.0 - saturation) * weight_g,
+                b_adjusted * (saturation * (1.0 - weight_b) + weight_b),
+            ];
+
             if self.debug_enabled {
                 log_decorated!("Creating CTM matrix...");
                 log_indented!(
-                    "temp={}K, gamma={:.0}%, RGB factors=({:.3}, {:.3}, {:.3})",
+                    "temp={}K, gamma={:.0}%, saturation={:.3}",
                     self.current_temperature,
                     self.current_gamma_percent,
-                    r,
-                    g,
-                    b
+                    saturation
                 );
                 log_decorated!("CTM matrix (3x3):");
-                log_indented!("[{:.3}  0.000  0.000]", r_adjusted);
-                log_indented!("[0.000  {:.3}  0.000]", g_adjusted);
-                log_indented!("[0.000  0.000  {:.3}]", b_adjusted);
+                log_indented!("[{:.3}  {:.3}  {:.3}]", ctm[0], ctm[1], ctm[2]);
+                log_indented!("[{:.3}  {:.3}  {:.3}]", ctm[3], ctm[4], ctm[5]);
+                log_indented!("[{:.3}  {:.3}  {:.3}]", ctm[6], ctm[7], ctm[8]);
             }
 
-            // Create CTM matrix (diagonal matrix with RGB values)
-            // CTM is row-major 3x3 matrix
-            // Convert to f64 for the protocol
-            let ctm = [
-                r_adjusted as f64,
-                0.0,
-                0.0,
-                0.0,
-                g_adjusted as f64,
-                0.0,
-                0.0,
-                0.0,
-                b_adjusted as f64,
-            ];
-
             // Set CTM for all outputs
+            // Convert to f64 for the protocol
             if self.debug_enabled {
                 log_decorated!("Setting CTM via Hyprland protocol");
             }
@@ -242,15 +250,15 @@ impl HyprlandBackend {
             for output_info in &self.state.outputs {
                 manager.set_ctm_for_output(
                     &output_info.output,
-                    ctm[0],
-                    ctm[1],
-                    ctm[2],
-                    ctm[3],
-                    ctm[4],
-                    ctm[5],
-                    ctm[6],
-                    ctm[7],
-                    ctm[8],
+                    ctm[0] as f64,
+                    ctm[1] as f64,
+                    ctm[2] as f64,
+                    ctm[3] as f64,
+                    ctm[4] as f64,
+                    ctm[5] as f64,
+                    ctm[6] as f64,
+                    ctm[7] as f64,
+                    ctm[8] as f64,
                 );
             }
 


### PR DESCRIPTION
An experiment to test desaturating screen before applying the temperature multiplier to improve readability of saturated colors.

### Problem

Imagine blue text on black background. When using very low temperatures, blue and green channels get multiplied to almost 0, making it hard to read (compared to greyscale or red text). Same thing for white text on red background - blue/green components get dimmed, and what remains is red on red... So potentially an accessibility thing.

### Solution

We can first partially desaturate the image and then apply the temperature correction. To do that, instead of using only the diagonal components of the CTM, we can split the contributions within each row. The result is the same overall temperature (no change for greyscale), but saturated text is more readable and images look (subjectively) more pleasant.

In this PR, I'm exponentially reducing saturation the further we get from 6500K (in the inverse space). There is one variable to control the desaturation strength, through experimentation I found 0.4 to work pretty well.

| 6500K | 1500K - Main | 1500K - PR |
| ----- | ------------ | ---------- |
| ![6500k](https://github.com/user-attachments/assets/95636df6-c004-442f-9a11-b6604abc57b9) | ![1500k_main](https://github.com/user-attachments/assets/895fbdd0-f41e-4c42-a74d-b81778f4886b) | ![1500k_pr](https://github.com/user-attachments/assets/b98be78e-71be-4751-81bb-d411d20a6aa2) |

*Attribution - calibration image found [here](https://cmac.smugmug.com/SmugMug/Prints/Test-prints/Calibration-prints/i-TccrMm3).*

Technically, it might be better to use some proper Chromatic Adaptation Transform, but I believe those can go negative, which `hyprland_ctm_control_v1` does not support anyway.

Works in Hyprland, currently no clue about other backends...