### PR TITLE
chore(nix): Update flake.lock file

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1762361079,
-        "narHash": "sha256-lz718rr1BDpZBYk7+G8cE6wee3PiBUpn8aomG/vLLiY=",
+        "lastModified": 1782175435,
+        "narHash": "sha256-EMzXKmnOtBQ2MnvpiNOm7E+kOMvdPrIKaeg52Tip2Uk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ffcdcf99d65c61956d882df249a9be53e5902ea5",
+        "rev": "89570f24e97e614aa34aa9ab1c927b6578a43775",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762569282,
-        "narHash": "sha256-vINZAJpXQTZd5cfh06Rcw7hesH7sGSvi+Tn+HUieJn8=",
+        "lastModified": 1782443907,
+        "narHash": "sha256-P+pADLtK7qC1mz0/5Xq9uF77oahUR4zYLTaitiHsUHg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a35a6144b976f70827c2fe2f5c89d16d8f9179d8",
+        "rev": "4b06ff4acf3491ff69721df852507fcc51d0a13d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The Nix flake fails to build for me on current `main` (d48641be2136196ecd8b09298abf1935e946c5f2).

```
$ nix build
error: builder for '/nix/store/9yjw0f54q7qxqpmy8932prbqrbrivwdq-sunsetr-0.12.3-d48641b.drv' failed with exit code 101;
       last 25 log lines:
       >    Compiling tracing v0.1.44
       >    Compiling sha256 v1.6.0
       >    Compiling zvariant_utils v3.4.0
       >    Compiling enumflags2 v0.7.12
       >    Compiling chrono v0.4.45
       >    Compiling zvariant_derive v5.12.0
       >    Compiling tzf-rs v1.3.3
       >    Compiling wayland-protocols-wlr v0.3.12
       >    Compiling zvariant v5.12.0
       >    Compiling sunrise v3.0.0
       >    Compiling zbus_names v4.3.2
       >    Compiling zbus_macros v5.16.0
       >    Compiling zbus v5.16.0
       >    Compiling sunsetr v0.12.3 (/build/source)
       > error[E0658]: use of unstable library feature `atomic_try_update`
       >   --> src/io/dbus.rs:70:14
       >    |
       > 70 |             .try_update(Ordering::SeqCst, Ordering::SeqCst, |v| {
       >    |              ^^^^^^^^^^
       >    |
       >    = note: see issue #135894 <https://github.com/rust-lang/rust/issues/135894> for more information
       >
       > For more information about this error, try `rustc --explain E0658`.
       > error: could not compile `sunsetr` (lib) due to 1 previous error
       > warning: build failed, waiting for other jobs to finish...
       For full logs, run:
         nix log /nix/store/9yjw0f54q7qxqpmy8932prbqrbrivwdq-sunsetr-0.12.3-d48641b.drv
``` 

I suppose this failure was introduced in 387cedb5cbdc3fd79b9695237e05f1bfb5449f5c last month, which also fails to build for me. I can successfully build on 2c18d9d5db5d70750fa2bac6907f3520aae508e5, the prior commit. 

Bumping the Nix flake.lock file seems to fix the issue for me on NixOS. I suppose the Rust feature used is only stable in a newer nixpkgs version. I verified the resultant binary runs on my machine (NixOS, wayland, Niri), though it would be wise to check other configurations as well. 